### PR TITLE
nix: added flake.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ For doing it locally, on Windows you can use a distribution like MikTex and a co
 
 [Windows + VSCode install](https://www.youtube.com/watch?v=4lyHIQl4VM8)
 
+For users of the Nix package manager, a flake is included that will spin up a shell with all of the required texlive dependencies by entering this repo's directory and calling ```nix develop```.
+
 ## Using LaTeX
 
 Here is a summarised list of examples for reference when writing your report.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1713805509,
+        "narHash": "sha256-YgSEan4CcrjivCNO5ZNzhg7/8ViLkZ4CB/GrGBVSudo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1e1dc66fe68972a76679644a5577828b6a7e8be4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,49 @@
+{
+    inputs = {
+        nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    };
+
+    outputs = { nixpkgs,  ... }: let
+        eachSys = nixpkgs.lib.genAttrs  [
+            "aarch64-darwin"
+            "aarch64-linux"
+            "x86_64-darwin"
+            "x86_64-linux"
+            "i686-darwin"
+            "i686-linux"
+        ];
+    in {
+        devShells = eachSys (system: let
+            pkgs = nixpkgs.legacyPackages.${system};
+        in {
+            default = pkgs.mkShell {
+                buildInputs = let
+                    texlive = pkgs.texlive.combine {
+                        inherit (pkgs.texlive)
+                        amsmath
+                        caption
+                        changepage
+                        datetime
+                        etoolbox
+                        fmtcount
+                        fancyhdr
+                        listings
+                        multirow
+                        paralist
+                        pdflscape
+                        setspace
+                        scheme-basic
+                        titlesec
+                        url
+                        xkeyval
+                        ;
+                    };
+                in builtins.attrValues {
+                    inherit texlive;
+                };
+            };
+        });
+    };
+
+}
+


### PR DESCRIPTION
Allows for users of the Nix package manager on Linux/MacOS to quickly spin up a nix-shell with the required texlive dependencies.